### PR TITLE
Disable antialiasing and depth buffer for WebGL2 contexts

### DIFF
--- a/src/renderer/webgl/WebglRenderer.ts
+++ b/src/renderer/webgl/WebglRenderer.ts
@@ -82,7 +82,8 @@ export class WebglRenderer extends EventEmitter implements IRenderer {
     this._renderDebouncer = new RenderDebouncer(this._terminal, this._renderRows.bind(this));
 
     this._canvas = document.createElement('canvas');
-    this._gl = this._canvas.getContext('webgl2') as IWebGL2RenderingContext;
+    const contextAttributes = { antialias: false, depth: false };
+    this._gl = this._canvas.getContext('webgl2', contextAttributes) as IWebGL2RenderingContext;
     if (!this._gl) {
         throw new Error('WebGL2 not supported');
     }


### PR DESCRIPTION
This was causing `getContext` and canvas size changes to be very expensive (taking 7-10X longer and blocking the main thread)