### PR TITLE
WebGL context loss handling

### DIFF
--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -466,17 +466,7 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
         }
         break;
       case 'rendererType':
-        if (this.renderer) {
-          this.unregister(this.renderer);
-          this.renderer.dispose();
-          this.renderer = null;
-        }
-        this._setupRenderer();
-        this.renderer.onCharSizeChanged();
-        if (this._theme) {
-          this.renderer.setTheme(this._theme);
-        }
-        this.mouseHelper.setRenderer(this.renderer);
+        this.recreateRenderer();
         break;
       case 'scrollback':
         this.buffers.resize(this.cols, this.rows);
@@ -502,6 +492,21 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     if (this.renderer) {
       this.renderer.onOptionsChanged();
     }
+  }
+
+  public recreateRenderer(): void {
+    if (this.renderer) {
+      this.unregister(this.renderer);
+      this.renderer.dispose();
+      this.renderer = null;
+    }
+    this._setupRenderer();
+    this.renderer.onCharSizeChanged();
+
+    if (this._theme) {
+      this.renderer.setTheme(this._theme);
+    }
+    this.mouseHelper.setRenderer(this.renderer);
   }
 
   /**
@@ -698,12 +703,13 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     // Performance: Add viewport and helper elements from the fragment
     this.element.appendChild(fragment);
 
-    this._setupRenderer();
     this._theme = this.options.theme;
     this.options.theme = null;
     this.viewport = new Viewport(this, this._viewportElement, this._viewportScrollArea, this.charMeasure);
-    this.viewport.onThemeChanged(this.renderer.colorManager.colors);
     this.register(this.viewport);
+
+    this._setupRenderer();
+    this.viewport.onThemeChanged(this.renderer.colorManager.colors);
 
     this.register(this.addDisposableListener('cursormove', () => this.renderer.onCursorMove()));
     this.register(this.addDisposableListener('resize', () => this.renderer.onResize(this.cols, this.rows)));
@@ -714,7 +720,6 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
     // matchMedia query.
     this.register(addDisposableDomListener(window, 'resize', () => this.renderer.onWindowResize(window.devicePixelRatio)));
     this.register(this.charMeasure.addDisposableListener('charsizechanged', () => this.renderer.onCharSizeChanged()));
-    this.register(this.renderer.addDisposableListener('resize', (dimensions) => this.viewport.syncScrollArea()));
 
     this.selectionManager = new SelectionManager(this, this.charMeasure);
     this.register(addDisposableDomListener(this.element, 'mousedown', (e: MouseEvent) => this.selectionManager.onMouseDown(e)));
@@ -758,11 +763,12 @@ export class Terminal extends EventEmitter implements ITerminal, IDisposable, II
 
   private _setupRenderer(): void {
     switch (this.options.rendererType) {
-      case 'canvas': this.renderer = new Renderer(this, this.options.theme); break;
-      case 'dom': this.renderer = new DomRenderer(this, this.options.theme); break;
-      case 'webgl': this.renderer = new WebglRenderer(this, this.options.theme); break;
+      case 'canvas': this.renderer = new Renderer(this, this._theme); break;
+      case 'dom': this.renderer = new DomRenderer(this, this._theme); break;
+      case 'webgl': this.renderer = new WebglRenderer(this, this._theme); break;
       default: throw new Error(`Unrecognized rendererType "${this.options.rendererType}"`);
     }
+    this.register(this.renderer.addDisposableListener('resize', (dimensions) => this.viewport.syncScrollArea()));
     this.register(this.renderer);
   }
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -230,6 +230,7 @@ export interface ITerminal extends PublicTerminal, IElementAccessor, IBufferAcce
   cancel(ev: Event, force?: boolean): boolean | void;
   log(text: string): void;
   showCursor(): void;
+  recreateRenderer(): void;
 }
 
 export interface IBufferAccessor {

--- a/src/renderer/webgl/WebglRenderer.ts
+++ b/src/renderer/webgl/WebglRenderer.ts
@@ -109,6 +109,10 @@ export class WebglRenderer extends EventEmitter implements IRenderer {
 
   public onIntersectionChange(entry: IntersectionObserverEntry): void {
     this._isPaused = entry.intersectionRatio === 0;
+    if (this._gl.isContextLost()) {
+      this._terminal.recreateRenderer();
+      return;
+    }
     if (!this._isPaused && this._needsFullRefresh) {
       this._terminal.refresh(0, this._terminal.rows - 1);
     }

--- a/src/renderer/webgl/WebglRenderer.ts
+++ b/src/renderer/webgl/WebglRenderer.ts
@@ -102,6 +102,7 @@ export class WebglRenderer extends EventEmitter implements IRenderer {
   }
 
   public dispose(): void {
+    super.dispose();
     this._renderLayers.forEach(l => l.dispose());
     this._terminal.screenElement.removeChild(this._canvas);
     super.dispose();

--- a/src/renderer/webgl/WebglRenderer.ts
+++ b/src/renderer/webgl/WebglRenderer.ts
@@ -20,6 +20,7 @@ import { CHAR_DATA_ATTR_INDEX, CHAR_DATA_CODE_INDEX, CHAR_DATA_CHAR_INDEX, NULL_
 import { IWebGL2RenderingContext } from './Types';
 import { INVERTED_DEFAULT_COLOR, DEFAULT_COLOR } from '../atlas/Types';
 import { RenderModel, COMBINED_CHAR_BIT_MASK } from './RenderModel';
+import { addDisposableDomListener } from '../../ui/Lifecycle';
 
 export const INDICIES_PER_CELL = 4;
 
@@ -39,9 +40,90 @@ export class WebglRenderer extends EventEmitter implements IRenderer {
 
   private _isPaused: boolean = false;
   private _needsFullRefresh: boolean = false;
+  private _salvaged: boolean = false;
 
   public dimensions: IRenderDimensions;
   public colorManager: ColorManager;
+
+  // Destroys paused renderes if the resources are needed for unpaused ones.
+  // This is unique to WebglRenderer because 'webgl2' contexts can become
+  // invalidated at any moment, typically by creating other canvases with
+  // 'webgl2' context, but also arbitrarily by the OS.
+  private static _contextHelper = new class {
+    private _recoverTimeout: any = null;
+
+    // Terminals ordered by least-recently-used first
+    private _lru: ITerminal[] = [];
+
+    // Renderers that lost context and need to be recreated
+    private _pendingRecover: WebglRenderer[] = [];
+
+    // Called when a renderer is created or unpaused to signify that the user
+    // just used this terminal. Terminals are kept in least-recently-used order,
+    // so that if resources are needed, we can sacrifice the least important
+    // ones
+    public onRendererUnpaused(renderer: WebglRenderer) {
+      const index = this._lru.indexOf(renderer._terminal);
+      if (index >= 0) {
+        this._lru.splice(index, 1);
+      }
+      this._lru.push(renderer._terminal);
+    }
+
+    public onRendererCreated(renderer: WebglRenderer) {
+      this.onRendererUnpaused(renderer);
+    }
+
+
+    public onRendererDestroyed(renderer: WebglRenderer) {
+      const index = this._lru.indexOf(renderer._terminal);
+      this._lru.splice(index, 1);
+    }
+
+    public recoverContext(renderer: WebglRenderer) {
+      this._pendingRecover.push(renderer);
+      if (!this._recoverTimeout) {
+        this._recoverTimeout = setTimeout(() => {
+          this._recoverTimeout = null;
+
+          // webglcontextlost can fire before resize observer, which means that some
+          // of the renderers that are pending recovery, might not actually need it,
+          // if they were paused
+          const toRecover = this._pendingRecover.filter(({ _isPaused }) => !_isPaused);
+          this._pendingRecover = [];
+          this._recoverPendingContexts(toRecover)
+        }, 0);
+      }
+    }
+
+    private _recoverPendingContexts(toRecover: WebglRenderer[]) {
+      // This terminal's context was lost but it's not paused, try to dispose the
+      // paused renderers to make room for this one
+      let killCount = 0;
+      for (let term of this._lru) {
+        const renderer = <WebglRenderer>term.renderer;
+        if (renderer._isPaused && !renderer._gl.isContextLost()) {
+          renderer._gl.getExtension('WEBGL_lose_context').loseContext()
+          renderer._salvaged = true;
+
+          // Only kill enough to recover all the pending contexts
+          killCount++;
+          if (killCount >= toRecover.length) {
+            break;
+          }
+        }
+      }
+
+      // If we managed to release some resources, try to recreate thes renderer
+      if (killCount > 0) {
+        toRecover.forEach((renderer) => {
+          renderer._terminal.recreateRenderer()
+        });
+      } else {
+        console.error('Too many simultaneous webgl contexts');
+      }
+    }
+  }
 
   constructor(
     private _terminal: ITerminal,
@@ -87,6 +169,7 @@ export class WebglRenderer extends EventEmitter implements IRenderer {
     if (!this._gl) {
         throw new Error('WebGL2 not supported');
     }
+    this.register(addDisposableDomListener(this._canvas, 'webglcontextlost', () => { this._onContextLost() }));
     this._terminal.screenElement.appendChild(this._canvas);
 
     this._rectangleRenderer = new RectangleRenderer(this._terminal, this.colorManager, this._gl, this.dimensions);
@@ -95,27 +178,51 @@ export class WebglRenderer extends EventEmitter implements IRenderer {
     // Detect whether IntersectionObserver is detected and enable renderer pause
     // and resume based on terminal visibility if so
     if ('IntersectionObserver' in window) {
-      const observer = new IntersectionObserver(e => this.onIntersectionChange(e[0]), { threshold: 0 });
+      const observer = new IntersectionObserver(e => this._onIntersectionChange(e[0]), { threshold: 0 });
       observer.observe(this._terminal.element);
       this.register({ dispose: () => observer.disconnect() });
     }
+
+    WebglRenderer._contextHelper.onRendererCreated(this);
   }
 
   public dispose(): void {
-    super.dispose();
     this._renderLayers.forEach(l => l.dispose());
     this._terminal.screenElement.removeChild(this._canvas);
     super.dispose();
+    this._canvas.width = 0;
+    this._canvas.height = 0;
+
+    WebglRenderer._contextHelper.onRendererDestroyed(this);
   }
 
-  public onIntersectionChange(entry: IntersectionObserverEntry): void {
-    this._isPaused = entry.intersectionRatio === 0;
-    if (this._gl.isContextLost()) {
-      this._terminal.recreateRenderer();
+  private _onContextLost(): void {
+    if (this._salvaged) {
+      this._salvaged = false;
       return;
     }
-    if (!this._isPaused && this._needsFullRefresh) {
-      this._terminal.refresh(0, this._terminal.rows - 1);
+
+    WebglRenderer._contextHelper.recoverContext(this);
+  }
+
+  private _onIntersectionChange(entry: IntersectionObserverEntry): void {
+    const wasPaused = this._isPaused;
+    this._isPaused = entry.intersectionRatio === 0;
+
+    if (!this._isPaused) {
+      if (wasPaused) {
+        WebglRenderer._contextHelper.onRendererUnpaused(this);
+      }
+      if (this._gl.isContextLost()) {
+        WebglRenderer._contextHelper.recoverContext(this);
+
+        // Return here because this renderer will be re-created to acquire a
+        // valid context, so there's no point in refreshing this one
+        return;
+      }
+      if (this._needsFullRefresh) {
+        this._terminal.refresh(0, this._terminal.rows - 1);
+      }
     }
   }
 

--- a/src/ui/TestUtils.test.ts
+++ b/src/ui/TestUtils.test.ts
@@ -157,6 +157,9 @@ export class MockTerminal implements ITerminal {
   showCursor(): void {
     throw new Error('Method not implemented.');
   }
+  recreateRenderer(): void {
+    throw new Error('Method not implemented.');
+  }
   refresh(start: number, end: number): void {
     throw new Error('Method not implemented.');
   }


### PR DESCRIPTION
This PR adds a helper class in `WebglRenderer` that manages webgl contexts. This is needed because:

 - Contexts can be lost at any time if the driver decides that it needs the resources for something else.
 - At least one browser (chrome) has a limit to the number of simultaneous contexts that can exist at any given time.

When a context is lost:
  - if the terminal is paused: don't do anything, it'll be recreated when unpausing
  - if the terminal is unpaused: try to kill a paused terminal to free up resources and recover the context immediately
    - if there are not enough paused terminals, it means we've reached the max number of webgl contexts allowed by the browser, so print a warning and give up.

When a renderer is unpaused, if its context has been lost, we simply get rid of the whole renderer and ask `Terminal` to create a new one.

Renderers are kept ordered by least-recently-used so that less used ones are killed first when resources are needed.

If one of the context that are being recovered was *just* lost, it means that we're currently at a resource limit so we need to kill a few paused renderers. if we fail to release other contexts (i.e. everything is unpaused), there's no point in trying to recover anything because we would be killing an unpaused renderers. In this case, just give up.

----
I used a class expression to have access to `WebglRenderer` private fields while keeping this whole thing encapsulated
